### PR TITLE
Error contenttype

### DIFF
--- a/src/Digipolis.Web/Exceptions/ExceptionHandler.cs
+++ b/src/Digipolis.Web/Exceptions/ExceptionHandler.cs
@@ -38,7 +38,7 @@ namespace Digipolis.Web.Exceptions
             if (!string.IsNullOrWhiteSpace(error.Title) || !string.IsNullOrWhiteSpace(error.Code) || error.Type != null || error.ExtraParameters?.Any() == true)
             {
                 context.Response.Clear();
-                context.Response.ContentType = "application/json";
+                context.Response.ContentType = "application/problem+json";
                 if (error.Status != default(int)) context.Response.StatusCode = error.Status;
                 var json = JsonConvert.SerializeObject(error, _options?.Value?.SerializerSettings ?? new JsonSerializerSettings());
                 await context.Response.WriteAsync(json);
@@ -56,7 +56,7 @@ namespace Digipolis.Web.Exceptions
             if (!string.IsNullOrWhiteSpace(error.Title) || !string.IsNullOrWhiteSpace(error.Code) || error.Type != null || error.ExtraParameters?.Any() == true)
             {
                 context.Response.Clear();
-                context.Response.ContentType = "application/json";
+                context.Response.ContentType = "application/problem+json";
                 if (error.Status != default(int)) context.Response.StatusCode = error.Status;
                 var json = JsonConvert.SerializeObject(error, _options?.Value?.SerializerSettings ?? new JsonSerializerSettings());
                 context.Response.WriteAsync(json).Wait();

--- a/test/Digipolis.Web.UnitTests/Exceptions/ExceptionHandlerTests.cs
+++ b/test/Digipolis.Web.UnitTests/Exceptions/ExceptionHandlerTests.cs
@@ -53,6 +53,7 @@ namespace Digipolis.Web.UnitTests.Exceptions
             var ctx = MockHelpers.HttpContext();
             handler.Handle(ctx, new AggregateException());
             Assert.Equal(400, ctx.Response.StatusCode);
+            Assert.Equal("application/problem+json", ctx.Response.ContentType);
         }
 
         [Fact]
@@ -62,6 +63,7 @@ namespace Digipolis.Web.UnitTests.Exceptions
             var ctx = MockHelpers.HttpContext();
             handler.Handle(ctx, new Exception());
             Assert.Equal(500, ctx.Response.StatusCode);
+            Assert.Equal("application/problem+json", ctx.Response.ContentType);
         }
 
         [Fact]
@@ -71,6 +73,7 @@ namespace Digipolis.Web.UnitTests.Exceptions
             var ctx = MockHelpers.HttpContext();
             handler.Handle(ctx, new AbandonedMutexException());
             Assert.Equal(500, ctx.Response.StatusCode);
+            Assert.Equal("application/problem+json", ctx.Response.ContentType);
         }
 
         [Fact]
@@ -89,6 +92,7 @@ namespace Digipolis.Web.UnitTests.Exceptions
             var ctx = MockHelpers.HttpContext();
             await handler.HandleAsync(ctx, new AggregateException());
             Assert.Equal(400, ctx.Response.StatusCode);
+            Assert.Equal("application/problem+json", ctx.Response.ContentType);
         }
 
         [Fact]
@@ -98,6 +102,7 @@ namespace Digipolis.Web.UnitTests.Exceptions
             var ctx = MockHelpers.HttpContext();
             await handler.HandleAsync(ctx, new Exception());
             Assert.Equal(500, ctx.Response.StatusCode);
+            Assert.Equal("application/problem+json", ctx.Response.ContentType);
         }
 
         [Fact]
@@ -107,6 +112,7 @@ namespace Digipolis.Web.UnitTests.Exceptions
             var ctx = MockHelpers.HttpContext();
             await handler.HandleAsync(ctx, new AbandonedMutexException());
             Assert.Equal(500, ctx.Response.StatusCode);
+            Assert.Equal("application/problem+json", ctx.Response.ContentType);
         }
 
         [Fact]


### PR DESCRIPTION
API error response models require content type application/problem+json, conforming the inhouse API design requirements.